### PR TITLE
Feature gpio pin controller class. Sets pin 4 high on EXAC

### DIFF
--- a/Linux/Car_Client/Car_Client.pro
+++ b/Linux/Car_Client/Car_Client.pro
@@ -27,6 +27,7 @@ CONFIG += console
 TEMPLATE = app
 
 SOURCES += main.cpp \
+    gpio.cpp \
     packetinterface.cpp \
     tcpbroadcast.cpp \
     utility.cpp \
@@ -45,6 +46,7 @@ SOURCES += main.cpp \
     vbytearray.cpp
 
 HEADERS += \
+    gpio.h \
     packetinterface.h \
     tcpbroadcast.h \
     utility.h \

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -18,6 +18,7 @@
 #include "chronoscomm.h"
 #include <QDateTime>
 #include <cmath>
+#include <wiringPi.h>
 
 ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
 {
@@ -826,7 +827,8 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                  break;
              }
          }
-        //TODO: handle ACCM message
+         digitalWrite (21, HIGH); delay(500);
+         digitalWrite (21,  LOW); delay(500);
     } break;
 
     case ISO_MSG_EXAC: {
@@ -850,7 +852,8 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-        //TODO: handle EXAC message
+        digitalWrite (21, HIGH); delay(500);
+        digitalWrite (21,  LOW); delay(500);
     } break;
 
     default:

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -18,15 +18,13 @@
 #include "chronoscomm.h"
 #include <QDateTime>
 #include <cmath>
-#include <wiringPi.h>
-
-#define PIN_NUMBER 0
 
 ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
 {
     mTcpServer = new TcpServerSimple(this);
     mUdpSocket = new QUdpSocket(this);
     mTcpSocket = new QTcpSocket(this);
+    mGpioControl = new GPIO();
 
     mTcpSocket->setSocketOption(QAbstractSocket::LowDelayOption, true);
     mUdpSocket->setSocketOption(QAbstractSocket::LowDelayOption, true);
@@ -50,11 +48,7 @@ ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
     connect(mTcpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
             this, SLOT(tcpInputError(QAbstractSocket::SocketError)));
 
-    wiringPiSetup() ;
-    pinMode (PIN_NUMBER, OUTPUT) ;
-    //TEMP ENSURE PIN IS LOW
-
-    digitalWrite (PIN_NUMBER,  LOW);
+    mGpioControl->setGPIO_Out(4);
 }
 
 bool ChronosComm::startObject()
@@ -858,7 +852,7 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-        digitalWrite (PIN_NUMBER, HIGH);
+    mGpioControl->GPIO_Write(4, 1);
     } break;
 
     default:

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -134,6 +134,8 @@ void ChronosComm::closeConnection()
     mTcpSocket->close();
     mUdpSocket->close();
     mTcpState = 0;
+    mGpioControl->GPIO_Write(4, 0);
+    mGpioControl->unsetGPIO(4);
     mCommMode = COMM_MODE_UNDEFINED;
 }
 

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -19,6 +19,8 @@
 #include <QDateTime>
 #include <cmath>
 
+#define PIN_OUT 4
+
 ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
 {
     mTcpServer = new TcpServerSimple(this);
@@ -48,7 +50,7 @@ ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
     connect(mTcpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
             this, SLOT(tcpInputError(QAbstractSocket::SocketError)));
 
-    mGpioControl->setGPIO_Out(4);
+    mGpioControl->setGPIO_Out(PIN_OUT);
 }
 
 bool ChronosComm::startObject()
@@ -134,8 +136,8 @@ void ChronosComm::closeConnection()
     mTcpSocket->close();
     mUdpSocket->close();
     mTcpState = 0;
-    mGpioControl->GPIO_Write(4, 0);
-    mGpioControl->unsetGPIO(4);
+    mGpioControl->GPIO_Write(PIN_OUT, 0);
+    mGpioControl->unsetGPIO(PIN_OUT);
     mCommMode = COMM_MODE_UNDEFINED;
 }
 
@@ -854,7 +856,7 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-    mGpioControl->GPIO_Write(4, 1);
+    mGpioControl->GPIO_Write(PIN_OUT, 1);
     } break;
 
     default:

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -49,8 +49,6 @@ ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
             this, SLOT(tcpInputDisconnected()));
     connect(mTcpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
             this, SLOT(tcpInputError(QAbstractSocket::SocketError)));
-
-    mGpioControl->setGPIO_Out(PIN_OUT);
 }
 
 bool ChronosComm::startObject()
@@ -833,7 +831,9 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                  break;
              }
          }
-    } break;
+         mGpioControl->unsetGPIO(PIN_OUT);
+         mGpioControl->setGPIO_Out(PIN_OUT);
+       } break;
 
     case ISO_MSG_EXAC: {
         chronos_EXAC exac;
@@ -856,7 +856,8 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-    mGpioControl->GPIO_Write(PIN_OUT, 1);
+    if(exac.actionID == )
+        mGpioControl->GPIO_Write(PIN_OUT, 1);
     } break;
 
     default:

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -20,6 +20,8 @@
 #include <cmath>
 #include <wiringPi.h>
 
+#define PIN_NUMBER 0
+
 ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
 {
     mTcpServer = new TcpServerSimple(this);
@@ -47,6 +49,12 @@ ChronosComm::ChronosComm(QObject *parent) : QObject(parent)
             this, SLOT(tcpInputDisconnected()));
     connect(mTcpSocket, SIGNAL(error(QAbstractSocket::SocketError)),
             this, SLOT(tcpInputError(QAbstractSocket::SocketError)));
+
+    wiringPiSetup() ;
+    pinMode (PIN_NUMBER, OUTPUT) ;
+    //TEMP ENSURE PIN IS LOW
+
+    digitalWrite (PIN_NUMBER,  LOW);
 }
 
 bool ChronosComm::startObject()
@@ -827,8 +835,6 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                  break;
              }
          }
-         digitalWrite (21, HIGH); delay(500);
-         digitalWrite (21,  LOW); delay(500);
     } break;
 
     case ISO_MSG_EXAC: {
@@ -852,8 +858,7 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-        digitalWrite (21, HIGH); delay(500);
-        digitalWrite (21,  LOW); delay(500);
+        digitalWrite (PIN_NUMBER, HIGH);
     } break;
 
     default:

--- a/Linux/Car_Client/chronoscomm.cpp
+++ b/Linux/Car_Client/chronoscomm.cpp
@@ -856,7 +856,6 @@ bool ChronosComm::decodeMsg(quint16 type, quint32 len, QByteArray payload, uint8
                 break;
             }
         }
-    if(exac.actionID == )
         mGpioControl->GPIO_Write(PIN_OUT, 1);
     } break;
 

--- a/Linux/Car_Client/chronoscomm.h
+++ b/Linux/Car_Client/chronoscomm.h
@@ -23,6 +23,8 @@
 #include <QTimer>
 #include <vbytearrayle.h>
 #include <tcpserversimple.h>
+#include "gpio.h"
+
 
 typedef enum {
     COMM_MODE_UNDEFINED = 0,
@@ -234,6 +236,7 @@ private:
     TcpServerSimple *mTcpServer;
     QTcpSocket *mTcpSocket;
     QUdpSocket *mUdpSocket;
+    GPIO* mGpioControl;
     QHostAddress mUdpHostAddress;
     quint16 mUdpPort;
     quint8 mTransmitterId;
@@ -245,6 +248,8 @@ private:
     quint32 mTcpLen;
     quint16 mTcpChecksum;
     VByteArrayLe mTcpData;
+
+
 
     void mkChronosHeader(VByteArrayLe &vb,
                          quint8 transmitter_id,

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -1,0 +1,6 @@
+#include "gpio.h"
+
+GPIO::GPIO()
+{
+
+}

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -76,14 +76,14 @@ int GPIO::GPIO_Write(int pin, int value)
         fprintf(stderr, "ERROR: Invalid value!\nValue must be 0 or 1\n");
         return -1;
     }
-    FILE *sysfs_handle = NULL;
+    FILE *sysfsHandle = NULL;
     char strValueFile[STR_LENGTH];
 
     snprintf (strValueFile, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/value", pin);
 
-    if ((sysfs_handle = fopen(strValueFile, "w")) == NULL)
+    if ((sysfsHandle = fopen(strValueFile, "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\n Has the pin been exported?\n", pin);
+        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\nHas the pin been exported?\n", pin);
         return 1;
     }
 

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -1,6 +1,138 @@
 #include "gpio.h"
 
-GPIO::GPIO()
+GPIO::GPIO(QObject *parent)
 {
 
+}
+
+GPIO::~GPIO(){
+
+}
+
+int GPIO::setGPIO_Out(int pin)
+{
+    int gpio_pins[]={GPIO_PINS};
+    int valid = 0;
+
+    //Check if valid GPIO pin
+    for (int i=0; i<(sizeof(gpio_pins) / sizeof(int)); i++)
+    {
+        if(pin == gpio_pins[i]){
+            valid = 1;
+        }
+
+    }
+
+    if(!valid)
+    {
+        fprintf(stderr, "ERROR: Invalid pin!\nPin %d is not a GPIO pin or already in use\n", pin);
+        return -1;
+    }
+
+    FILE *sysfsHandle = NULL;
+
+    if ((sysfsHandle = fopen("/sys/class/gpio/export", "w")) == NULL)
+    {
+        fprintf(stderr, "ERROR: Cannot open GPIO export...\n");
+        return 1;
+    }
+
+    //convert pin number to str
+    char strPin[3];
+    printf(strPin, (3*sizeof(char)), "%d", pin);
+
+    //Eport pin by writing to the gpio/export file
+    if (fwrite(&strPin, sizeof(char), 3, sysfsHandle)!=3)
+    {
+        fprintf(stderr, "ERROR: Unable to export GPIO pin %d\n", pin);
+        return 2;
+    }
+    fclose(sysfsHandle);
+
+    //Set direction in direction file
+    char str_direction_file[STR_LENGTH];
+    snprintf(str_direction_file, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/direction", pin);
+    if ((sysfsHandle = fopen(str_direction_file, "w")) == NULL)
+    {
+        fprintf(stderr, "ERROR: Cannot open direction file...\n");
+        return 3;
+    }
+
+    //write "out" to the direction file.
+    if (fwrite("out", sizeof(char), 4, sysfsHandle) != 4)
+    {
+        fprintf(stderr, "ERROR: Unable to write direction for GPIO%d\n", pin);
+        return 4;
+    }
+    fclose(sysfsHandle);
+
+    return 0;
+}
+
+int GPIO::GPIO_Write(int pin, int value)
+{
+    if ((value!=0)&&(value!=1))
+    {
+        fprintf(stderr, "ERROR: Invalid value!\nValue must be 0 or 1\n");
+        return -1;
+    }
+    FILE *sysfs_handle = NULL;
+    char strValueFile[STR_LENGTH];
+
+    snprintf (strValueFile, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/value", pin);
+
+    if ((sysfs_handle = fopen(strValueFile, "w")) == NULL)
+    {
+        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\n Has the pin been exported?\n", pin);
+        return 1;
+    }
+
+    char strVal[2];
+    snprintf (strVal, (2*sizeof(char)), "%d", value);
+
+    if(fwrite(strVal, sizeof(char), 2, sysfs_handle) != 2)
+    {
+        fprintf(stderr, "ERROR: Cannot write value %d to GPIO pin %d\n", value, pin);
+        return 2;
+    }
+    fclose(sysfs_handle);
+
+    return 0;
+}
+
+int GPIO::unsetGPIO(int pin)
+{
+    FILE *sysfsHandle = NULL;
+    char strPin[3];
+    char strValueFile[STR_LENGTH];
+
+    snprintf (strPin, (3*sizeof(char)), "%d", pin);
+    snprintf (strValueFile, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/value", pin);
+
+    if ((sysfsHandle = fopen(strValueFile, "w")) == NULL)
+    {
+        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\n", pin);
+        return 1;
+    }
+
+    if(fwrite("0", sizeof(char), 2, sysfsHandle) != 2)
+    {
+        fprintf(stderr, "ERROR: Cannot write to GPIO pin %d\n", pin);
+        return 2;
+    }
+    fclose(sysfsHandle);
+
+    if ((sysfsHandle = fopen("/sys/class/gpio/unexport", "w")) == NULL)
+    {
+        fprintf(stderr, "ERROR: Cannot open GPIO unexport...\n");
+        return 1;
+    }
+
+    if (fwrite(&strPin, sizeof(char), 3, sysfsHandle)!=3)
+    {
+        fprintf(stderr, "ERROR: Unable to unexport GPIO pin %d\n", pin);
+        return 2;
+    }
+    fclose(sysfsHandle);
+    return 0;
 }

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -14,6 +14,10 @@ GPIO::~GPIO(){
 
 }
 
+/*!
+ * \brief GPIO::setGPIO_Out defines a specific GPIO pin to be used as output
+ * \param pin number of the specified pin to be set as output
+ */
 int GPIO::setGPIO_Out(int pin)
 {
     int gpio_pins[]={GPIO_PINS};
@@ -140,4 +144,9 @@ int GPIO::unsetGPIO(int pin)
     }
     fclose(sysfsHandle);
     return 0;
+}
+
+int GPIO::checkGPIOstatus(int pin){
+
+
 }

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -34,7 +34,7 @@ int GPIO::setGPIO_Out(int pin)
 
     if(!valid)
     {
-        fprintf(stderr, "ERROR: Tried setting invalid pin to Out!\nPin %d is not a GPIO pin or already in use\n", pin);
+        fprintf(stderr, "ERROR: Tried setting invalid pin to OUT!\nPin %d is not a GPIO pin or already in use\n", pin);
         return -1;
     }
 
@@ -42,7 +42,7 @@ int GPIO::setGPIO_Out(int pin)
 
     if ((sysfsHandle = fopen("/sys/class/gpio/export", "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Cannot open GPIO export...\n", pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to OUT. Cannot open GPIO export...\n", pin);
         return 1;
     }
 
@@ -53,7 +53,7 @@ int GPIO::setGPIO_Out(int pin)
     //Eport pin by writing to the gpio/export file
     if (fwrite(&strPin, sizeof(char), 3, sysfsHandle)!=3)
     {
-        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Unable to export GPIO pin %d\n", pin, pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to OUT. Unable to export GPIO pin %d\n", pin, pin);
         return 2;
     }
     fclose(sysfsHandle);
@@ -63,17 +63,19 @@ int GPIO::setGPIO_Out(int pin)
     snprintf(str_direction_file, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/direction", pin);
     if ((sysfsHandle = fopen(str_direction_file, "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Cannot open direction file...\n", pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to OUT. Cannot open direction file...\n", pin);
         return 3;
     }
 
     //write "out" to the direction file.
     if (fwrite("out", sizeof(char), 4, sysfsHandle) != 4)
     {
-        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Unable to write direction for GPIO%d\n", pin, pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to OUT. Unable to write direction for GPIO %d\n", pin, pin);
         return 4;
     }
     fclose(sysfsHandle);
+
+    fprintf(stdout,"Set Pin %d as OUT\n", pin);
 
     return 0;
 }
@@ -105,6 +107,8 @@ int GPIO::GPIO_Write(int pin, int value)
         return 2;
     }
     fclose(sysfsHandle);
+
+    fprintf(stdout, "Set Pin %d to %d\n", pin, value);
 
     return 0;
 }
@@ -143,6 +147,9 @@ int GPIO::unsetGPIO(int pin)
         return 2;
     }
     fclose(sysfsHandle);
+
+    fprintf(stdout,"Unset Pin %d\n", pin);
+
     return 0;
 }
 

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -1,5 +1,10 @@
 #include "gpio.h"
 
+//TODO Check which are used for other things and remove these.
+
+#define GPIO_PINS 0, 1, 4, 7, 8, 9, 10, 11, 14, 15, 17, 18, 21, 22, 23, 24, 25
+#define STR_LENGTH 64
+
 GPIO::GPIO(QObject *parent)
 {
 

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -90,12 +90,12 @@ int GPIO::GPIO_Write(int pin, int value)
     char strVal[2];
     snprintf (strVal, (2*sizeof(char)), "%d", value);
 
-    if(fwrite(strVal, sizeof(char), 2, sysfs_handle) != 2)
+    if(fwrite(strVal, sizeof(char), 2, sysfsHandle) != 2)
     {
         fprintf(stderr, "ERROR: Cannot write value %d to GPIO pin %d\n", value, pin);
         return 2;
     }
-    fclose(sysfs_handle);
+    fclose(sysfsHandle);
 
     return 0;
 }

--- a/Linux/Car_Client/gpio.cpp
+++ b/Linux/Car_Client/gpio.cpp
@@ -34,7 +34,7 @@ int GPIO::setGPIO_Out(int pin)
 
     if(!valid)
     {
-        fprintf(stderr, "ERROR: Invalid pin!\nPin %d is not a GPIO pin or already in use\n", pin);
+        fprintf(stderr, "ERROR: Tried setting invalid pin to Out!\nPin %d is not a GPIO pin or already in use\n", pin);
         return -1;
     }
 
@@ -42,7 +42,7 @@ int GPIO::setGPIO_Out(int pin)
 
     if ((sysfsHandle = fopen("/sys/class/gpio/export", "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open GPIO export...\n");
+        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Cannot open GPIO export...\n", pin);
         return 1;
     }
 
@@ -53,7 +53,7 @@ int GPIO::setGPIO_Out(int pin)
     //Eport pin by writing to the gpio/export file
     if (fwrite(&strPin, sizeof(char), 3, sysfsHandle)!=3)
     {
-        fprintf(stderr, "ERROR: Unable to export GPIO pin %d\n", pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Unable to export GPIO pin %d\n", pin, pin);
         return 2;
     }
     fclose(sysfsHandle);
@@ -63,14 +63,14 @@ int GPIO::setGPIO_Out(int pin)
     snprintf(str_direction_file, (STR_LENGTH*sizeof(char)), "/sys/class/gpio/gpio%d/direction", pin);
     if ((sysfsHandle = fopen(str_direction_file, "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open direction file...\n");
+        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Cannot open direction file...\n", pin);
         return 3;
     }
 
     //write "out" to the direction file.
     if (fwrite("out", sizeof(char), 4, sysfsHandle) != 4)
     {
-        fprintf(stderr, "ERROR: Unable to write direction for GPIO%d\n", pin);
+        fprintf(stderr, "ERROR: Tried setting pin %d to Out. Unable to write direction for GPIO%d\n", pin, pin);
         return 4;
     }
     fclose(sysfsHandle);
@@ -82,7 +82,7 @@ int GPIO::GPIO_Write(int pin, int value)
 {
     if ((value!=0)&&(value!=1))
     {
-        fprintf(stderr, "ERROR: Invalid value!\nValue must be 0 or 1\n");
+        fprintf(stderr, "ERROR: Tried writing to pin %d with invalid value %d!\nValue must be 0 or 1\n", pin, value);
         return -1;
     }
     FILE *sysfsHandle = NULL;
@@ -92,7 +92,7 @@ int GPIO::GPIO_Write(int pin, int value)
 
     if ((sysfsHandle = fopen(strValueFile, "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\nHas the pin been exported?\n", pin);
+        fprintf(stderr, "ERROR: Tried writing to pin %d. Cannot open value file for pin.\nHas pin %d been exported?\n", pin, pin);
         return 1;
     }
 
@@ -101,7 +101,7 @@ int GPIO::GPIO_Write(int pin, int value)
 
     if(fwrite(strVal, sizeof(char), 2, sysfsHandle) != 2)
     {
-        fprintf(stderr, "ERROR: Cannot write value %d to GPIO pin %d\n", value, pin);
+        fprintf(stderr, "ERROR: Tried writing to pin %d. Cannot write value %d to GPIO pin %d\n", value, pin, pin);
         return 2;
     }
     fclose(sysfsHandle);
@@ -120,33 +120,30 @@ int GPIO::unsetGPIO(int pin)
 
     if ((sysfsHandle = fopen(strValueFile, "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open value file for pin %d...\n", pin);
+        fprintf(stderr, "ERROR: Tried unsetting pin %d. Unable open value file.", pin);
         return 1;
     }
 
     if(fwrite("0", sizeof(char), 2, sysfsHandle) != 2)
     {
-        fprintf(stderr, "ERROR: Cannot write to GPIO pin %d\n", pin);
+        fprintf(stderr, "ERROR: Tried unsetting pin %d. Cannot write to GPIO pin\n", pin);
         return 2;
     }
     fclose(sysfsHandle);
 
     if ((sysfsHandle = fopen("/sys/class/gpio/unexport", "w")) == NULL)
     {
-        fprintf(stderr, "ERROR: Cannot open GPIO unexport...\n");
+        fprintf(stderr, "ERROR: Tried unsetting pin %d. Cannot open GPIO unexport.\n", pin);
         return 1;
     }
 
     if (fwrite(&strPin, sizeof(char), 3, sysfsHandle)!=3)
     {
-        fprintf(stderr, "ERROR: Unable to unexport GPIO pin %d\n", pin);
+        fprintf(stderr, "ERROR: Tried unsetting pin %d. Unable to unexport GPIO pin.\n", pin);
         return 2;
     }
     fclose(sysfsHandle);
     return 0;
 }
 
-int GPIO::checkGPIOstatus(int pin){
 
-
-}

--- a/Linux/Car_Client/gpio.h
+++ b/Linux/Car_Client/gpio.h
@@ -1,0 +1,11 @@
+#ifndef GPIO_H
+#define GPIO_H
+
+
+class GPIO
+{
+public:
+    GPIO();
+};
+
+#endif // GPIO_H

--- a/Linux/Car_Client/gpio.h
+++ b/Linux/Car_Client/gpio.h
@@ -1,7 +1,6 @@
 #ifndef GPIO_H
 #define GPIO_H
 
-
 #include <QObject>
 #include <stdio.h>
 #include <string.h>
@@ -15,6 +14,7 @@ public:
     int setGPIO_Out(int pin);
     int GPIO_Write(int pin, int value);
     int unsetGPIO(int pin);
+    int checkGPIOstatus(int pin);
 };
 
 #endif // GPIO_H

--- a/Linux/Car_Client/gpio.h
+++ b/Linux/Car_Client/gpio.h
@@ -1,11 +1,23 @@
 #ifndef GPIO_H
 #define GPIO_H
 
+//TODO Check which are used for other things and remove these.
+#define GPIO_PINS 0, 1, 4, 7, 8, 9, 10, 11, 14, 15, 17, 18, 21, 22, 23, 24, 25
+#define STR_LENGTH 64
 
-class GPIO
+#include <QObject>
+#include <stdio.h>
+#include <string.h>
+class GPIO : public QObject
 {
+    Q_OBJECT
 public:
-    GPIO();
+    explicit GPIO(QObject *parent = 0);
+    ~GPIO();
+
+    int setGPIO_Out(int pin);
+    int GPIO_Write(int pin, int value);
+    int unsetGPIO(int pin);
 };
 
 #endif // GPIO_H

--- a/Linux/Car_Client/gpio.h
+++ b/Linux/Car_Client/gpio.h
@@ -1,6 +1,7 @@
 #ifndef GPIO_H
 #define GPIO_H
 
+
 #include <QObject>
 #include <stdio.h>
 #include <string.h>

--- a/Linux/Car_Client/gpio.h
+++ b/Linux/Car_Client/gpio.h
@@ -1,10 +1,6 @@
 #ifndef GPIO_H
 #define GPIO_H
 
-//TODO Check which are used for other things and remove these.
-#define GPIO_PINS 0, 1, 4, 7, 8, 9, 10, 11, 14, 15, 17, 18, 21, 22, 23, 24, 25
-#define STR_LENGTH 64
-
 #include <QObject>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Added a GPIO class that using sysf enables setting pins as output pins and setting this pin to 1 or 0 
Currently sets pin 4 to 1 when reveiving EXAC